### PR TITLE
Feature: Add handling for temp file removal to not leave stale files behind

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -28,7 +28,7 @@ public:
 
 private slots:
     void saveBufferToFile();
-    void loadAtOffsetDialog(QString path = {});
+    void loadAtOffsetDialog(QString path = {}, bool deleteOnFinish = false);
     void loadFileAppendDialog();
     void onDevicesScanned(const QStringList &names);
     void onDevicesListed(const QStringList &names);
@@ -91,6 +91,7 @@ private:
     // In-memory buffer
     QByteArray buffer_;
     QString    lastPath_;
+    QString    pendingWriteTempPath_;
 
     // Buffer segment legend storage
     struct BufferSegment {

--- a/src/ProcessHandling.cpp
+++ b/src/ProcessHandling.cpp
@@ -7,6 +7,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QDateTime>
+#include <QFile>
 
 // Constructor
 ProcessHandling::ProcessHandling(QObject *parent)
@@ -480,11 +481,13 @@ void ProcessHandling::handleFinished(int exitCode, QProcess::ExitStatus status) 
     // Logic chip test
     } else if (mode_ == Mode::Reading) {
         const bool ok = (status == QProcess::NormalExit && exitCode == 0);
-        // print debug info
+        const QString tempPath = pendingTempPath_;
+        pendingTempPath_.clear();
         if (ok) {
             mode_ = Mode::Idle;
-            emit readReady(pendingTempPath_);
+            emit readReady(tempPath);
         } else {
+            if (!tempPath.isEmpty()) QFile::remove(tempPath);
             mode_ = Mode::Idle;
             emit errorLine(QString("[Read error] exit=%1").arg(exitCode));
         }


### PR DESCRIPTION
FireMinipro created a lot of temp files during the runtime, but handling of the temp file deletion was not implemented and stale files were left behind.

This PR implements proper temp file deletion.